### PR TITLE
docs: simplify clone instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ escalabilidade e resiliência.
 ### 1. Clonar o repositório
 
 ```sh
-git clone https://github.com/thoggs/order-management-platform.git
-cd order-management-platform
+git clone https://github.com/thoggs/order-management-platform.git && cd order-management-platform
 ```
 
 ### 2. Configurar variáveis de ambiente


### PR DESCRIPTION
- Combine `git clone` and `cd` commands into a single line for improved clarity and ease of use.