### PR TITLE
Update RabbitMQ password hash and fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,15 @@ escalabilidade e resiliência.
 
 ### 3. Subir a infraestrutura (RabbitMQ, PostgreSQL, Redis)
 
-```sh
-docker compose -f docker-compose-infra.yml up -d
-```
-
-### 4. Definir senha do RabbitMQ
-
-```sh
-docker exec -it order-message-broker rabbitmqctl change_password admin secret
-```
+   ```sh
+   docker compose -f docker-compose-infra.yml up -d
+   ```
 
 ### 5. Subir os serviços da aplicação
 
-```sh
-docker compose -f docker-compose-app.yml up -d
-```
+   ```sh
+   docker compose -f docker-compose-app.yml up -d
+   ```
 
 Os seguintes serviços Spring Boot são iniciados em background:
 

--- a/config/rabbitmq/definitions.json
+++ b/config/rabbitmq/definitions.json
@@ -2,7 +2,7 @@
   "users": [
     {
       "name": "admin",
-      "password_hash": "nTrnSuLBC4NvENi0Er1bdoyVfJj0V5F08qfZqXcFJG8=",
+      "password_hash": "kiSPyz/byj9s2oee9dO0xVnyN02UJ3454CAQa7T+vI5oAscg",
       "hashing_algorithm": "rabbit_password_hashing_sha256",
       "tags": [
         "administrator"


### PR DESCRIPTION
- Update the `password_hash` for the RabbitMQ admin user in `definitions.json`.
- Correct README code block formatting by adding proper indentation.
- Remove outdated instructions for changing the RabbitMQ password via CLI.