### PR TITLE
Update command for starting infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ escalabilidade e resiliência.
 ### 3. Subir a infraestrutura (RabbitMQ, PostgreSQL, Redis) e os serviços da aplicação
 
    ```sh
-   docker compose -f docker-compose-infra.yml up -d
+   docker compose docker-compose.yml up -d
    ```
 
 Os seguintes serviços Spring Boot são iniciados em background:


### PR DESCRIPTION
- Correct the command in the README to use `docker compose docker-compose.yml up -d` instead of `docker compose -f docker-compose-infra.yml up -d`.
- Ensure instructions align with the correct docker-compose file.