### PR TITLE
Fix indentation in RabbitMQ Management UI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ http://localhost:8282/swagger-ui/index.html?lang=pt-BR
 #### RabbitMQ Management UI
 
 - URL: [http://localhost:15672](http://localhost:15672)
-  - Usuário: `admin`
-  - Senha: `secret`
+
+    - Usuário: `admin`
+    - Senha: `secret`
 
 ## Executando Teste de Carga
 


### PR DESCRIPTION
- Correct indentation for the user (`Usuário`) and password (`Senha`) fields in the README for better readability.