### PR TITLE
Switch services to prebuilt images in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,13 +51,9 @@ services:
 
   sboot-order-processor:
     container_name: sboot-order-processor
-    build:
-      context: https://github.com/thoggs/sboot-order-processor.git
-      args:
-        JAVA_VERSION: 21
-        GRADLE_VERSION: 8.11
+    image: thoggs/sboot-order-processor:latest
     ports:
-      - '8282:8080'
+      - "8282:8080"
     env_file:
       - environments/order-processor.env
     depends_on:
@@ -69,13 +65,9 @@ services:
 
   sboot-order-dispatcher:
     container_name: sboot-order-dispatcher
-    build:
-      context: https://github.com/thoggs/sboot-order-dispatcher.git
-      args:
-        JAVA_VERSION: 21
-        GRADLE_VERSION: 8.11
+    image: thoggs/sboot-order-dispatcher:latest
     ports:
-      - '8383:8080'
+      - "8383:8080"
     env_file:
       - environments/order-dispatcher.env
     depends_on:


### PR DESCRIPTION
- Replace `build` configuration with `image` for `sboot-order-processor` and `sboot-order-dispatcher` to use prebuilt Docker images (`thoggs/sboot-order-processor:latest` and `thoggs/sboot-order-dispatcher:latest`).
- Standardize port mappings using double quotes for consistency.
- Simplify the deployment process by removing build arguments for Java and Gradle versions.