### PR TITLE
Update command in README for docker-compose usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ escalabilidade e resiliência.
 ### 3. Subir a infraestrutura (RabbitMQ, PostgreSQL, Redis) e os serviços da aplicação
 
    ```sh
-   docker compose docker-compose.yml up -d
+   docker compose up -d
    ```
 
 Os seguintes serviços Spring Boot são iniciados em background:


### PR DESCRIPTION
- Simplify the Docker Compose command by removing the redundant `docker-compose.yml` argument.